### PR TITLE
itemsテーブルの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ Things you may want to cover:
 |points|integer||
 |password|string|null: false|
 ### Association
-- has_many :item_users
-- has_many :items through: :item_users
+- has_many :items
 - has_many :comments
 - has_many :favorites
 - has_one  :profile
@@ -89,7 +88,8 @@ Things you may want to cover:
 |Column|Type|Options|
 |------|----|-------|
 |name|string||
-|buyer|string||
+|buyer_id|references|foreign_key: true|
+|seller_id|references|foreign_key: true|
 |size|string||
 |item_condition|string||
 |postage_payer|string||
@@ -102,11 +102,10 @@ Things you may want to cover:
 |category_id|string|foreign_key: true|
 |brand_id|string|foreign_key: true|
 ### Association
-- has_many :item_users
 - has_many :item_images
-- has_many :items through: :item_users
 - has_many :comments
 - has_many :favorites
+- belongs_to :user
 - belongs_to :brand
 - belongs_to :category
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,9 +1,8 @@
 class Item < ApplicationRecord
-  has_many :item_users
   has_many :item_images
-  has_many :items, through: :item_users
   has_many :comments
   has_many :favorites
+  belongs_to :user
   belongs_to :brand
   belongs_to :category
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_many :item_users
-  has_many :items, through: :item_users
+  has_many :items
   has_many :comments
   has_many :favorites
   has_one  :profile

--- a/db/migrate/20200305032152_create_items.rb
+++ b/db/migrate/20200305032152_create_items.rb
@@ -2,7 +2,8 @@ class CreateItems < ActiveRecord::Migration[5.2]
   def change
     create_table :items do |t|
       t.string :name
-      t.string :buyer
+      t.references :seller
+      t.references :buyer
       t.string :size
       t.string :item_condition
       t.string :postage_payer
@@ -16,5 +17,7 @@ class CreateItems < ActiveRecord::Migration[5.2]
       # t.references :brand, foreign_key: true
       t.timestamps
     end
+    add_foreign_key :items, :users, column: :seller_id
+    add_foreign_key :items, :users, column: :buyer_id
   end
 end

--- a/db/migrate/20200305032152_create_items.rb
+++ b/db/migrate/20200305032152_create_items.rb
@@ -2,8 +2,6 @@ class CreateItems < ActiveRecord::Migration[5.2]
   def change
     create_table :items do |t|
       t.string :name
-      t.references :seller
-      t.references :buyer
       t.string :size
       t.string :item_condition
       t.string :postage_payer
@@ -13,11 +11,8 @@ class CreateItems < ActiveRecord::Migration[5.2]
       t.text :item_description
       t.string :trading_status
       t.integer :price
-      # t.references :category, foreign_key: true
-      # t.references :brand, foreign_key: true
+      # referenceは'20200309065853_add_column_to_item'に記述
       t.timestamps
     end
-    add_foreign_key :items, :users, column: :seller_id
-    add_foreign_key :items, :users, column: :buyer_id
   end
 end

--- a/db/migrate/20200305054110_create_profiles.rb
+++ b/db/migrate/20200305054110_create_profiles.rb
@@ -11,7 +11,7 @@ class CreateProfiles < ActiveRecord::Migration[5.2]
       t.text :introduction
       t.string :image
       t.string :phone_number
-      # t.references :user, foreign_key: true
+      t.references :user, foreign_key: true
       t.timestamps
     end
   end

--- a/db/migrate/20200309065853_add_column_to_item.rb
+++ b/db/migrate/20200309065853_add_column_to_item.rb
@@ -1,0 +1,8 @@
+class AddColumnToItem < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :items, :seller, foreign_key: { to_table: :users }
+    add_reference :items, :buyer, foreign_key: { to_table: :users }
+    add_reference :items, :category, foreign_key: true
+    add_reference :items, :brand, foreign_key: true
+  end
+end


### PR DESCRIPTION
# What
多対多だったusersテーブルとitemsテーブルの関係を
一対多に設定し直しています。

# Why
商品が複数ユーザーをもつことはないため。

# Notes
- itemsテーブルにseller_idとbuyer_idを追加し、usersテーブルとつなげています