### PR TITLE
commit ビュー　商品説明文の追加と値段を修正

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -42,15 +42,14 @@
                    
           .main__content__main__item-box__price
             %span.main__content__main__item-box__price-price
-              ¥
-              = @item.price
+              = ('¥' + @item.price.to_s(:delimited))
             .main__content__main__item-box__price-detail
               %span
                 (税込)
               %span
                 送料込み
           .main__content__main__item-box__detail
-            = @item.name
+            = @item.item_description
           .main__content__main__item-box__table
             %table 
               %tr

--- a/app/views/tops/index.html.haml
+++ b/app/views/tops/index.html.haml
@@ -99,7 +99,7 @@
                   %h3= item.name
                   .details
                     %ul
-                      %li= item.price
+                      = ('¥' + item.price.to_s(:delimited))
                       %li
                         %i.fa.fa-star.likeIcon
                         0
@@ -121,7 +121,7 @@
                   %h3= item.name
                   .details
                     %ul
-                      %li= item.price
+                      = ('¥' + item.price.to_s(:delimited))
                       %li
                         %i.fa.fa-star.likeIcon
                         0


### PR DESCRIPTION
WHAT
商品詳細ページに商品説明文が表示されていない問題を修正
商品詳細ページ、商品一覧ページの値段表示にカンマを追加しました。
WHY
必須実装＋値段が見づらいため